### PR TITLE
styling: Increase font size for headings

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -5,4 +5,19 @@
   --md-accent-fg-color:          #D3506F;
   --md-footer-bg-color:          #2C2C2C;
   --md-footer-bg-color--dark:    #2C2C2C;
+  --md-default-fg-color--light:  #000000B0;
 }
+
+/* Heading overrides as the default ones are very small */
+.md-typeset {
+  h4 {
+    font-size: 0.95rem;
+  }
+  h5 {
+    font-size: 0.8rem;
+  }
+  h6 {
+    font-size: 0.7rem;
+  }
+}
+


### PR DESCRIPTION
I'm no frontend guru but trying to make the headings a little bit more legible as they're currently too small and use hard-to-parse colors. I imagine someone with more frontend taste can make a better overall change.

- Increase the heading sizes to more reasonable values.
- Change the color of the `h5` heading from light to dark gray
- The change is most obvious in its effect when viewing the Hypervisor page due to its heavy use of headings.