### PR TITLE
styling: Fix h5 colors in dark mode

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -5,7 +5,6 @@
   --md-accent-fg-color:          #D3506F;
   --md-footer-bg-color:          #2C2C2C;
   --md-footer-bg-color--dark:    #2C2C2C;
-  --md-default-fg-color--light:  #000000B0;
 }
 
 /* Heading overrides as the default ones are very small */


### PR DESCRIPTION
After adding dark mode in (#164), the fixed color override for `fg-color--light` no longer works as expected since the color can now be one of two options, and the override overrides it for both (light and dark) themes.

For now, delete this override and live with what's provided by the default styling. This works better than the current broken styling in dark mode where h5 headers show up as super dark text on a dark background.

I'm heading to work in a few mins so I didn't have time to research how to provide overrides for light/dark modes,
so deleting the override for now since it fixes the dark-text-on-dark-background issue in dark mode.