### PR TITLE
Add a build container

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,35 @@
+name: Container
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Log into the container registry
+        uses: docker/login-action@v3
+        if: github.event_name != 'pull_request'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build the container image
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          tags: AsahiLinux/mkdocs-asahi:latest
+          push: ${{ github.event_name != 'pull_request' }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#adding-a-description-to-multi-arch-images
+          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=Build the Asahi Linux documentation website using mkdocs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM registry.fedoraproject.org/fedora:41
+
+LABEL org.opencontainers.image.description="Build the Asahi Linux documentation website using mkdocs"
+LABEL org.opencontainers.image.licenses=MIT
+LABEL org.opencontainers.image.source=https://github.com/AsahiLinux/docs
+LABEL org.opencontainers.image.vendor="Asahi Linux"
+
+RUN dnf -y install mkdocs-material mkdocs-material+imaging python3-mkdocs-redirects && dnf -y clean all
+
+RUN mkdir /docs
+
+WORKDIR /docs
+
+EXPOSE 8000
+ENTRYPOINT ["mkdocs"]
+CMD ["serve", "--dev-addr=0.0.0.0:8000"]


### PR DESCRIPTION
This should make it a bit easier for folks to contribute to the docs without having to manually setup mkdocs and its dependencies.