### PR TITLE
Improve description of subvolumes and containers

### DIFF
--- a/docs/sw/partitioning-cheatsheet.md
+++ b/docs/sw/partitioning-cheatsheet.md
@@ -43,7 +43,15 @@ Warning: Some of Apple's tools do not like unsorted partitions in the GPT partit
 
 `disk0` is your NVMe drive. `disk0sN` is a GPT partition within it. `N` is *not* stable and is allocated dynamically by the macOS kernel. It does *not* correspond to the physical slot index in the GPT, nor does it correspond to the physical order of the partition data in the drive. Any time you create a partition, N can be allocated to a different number, and they can all be renumbered on reboot.
 
-`diskN` (`N` >= 1) could be a disk image or an external disk, but more likely is an *APFS container*. This is a hack that Apple came up with to represent subvolumes. The "partitions" within such a disk aren't real partitions, they just represent volumes within one APFS container. The container itself exists within a physical partition in `disk0`. That means that for APFS operations, for example, `disk0s2` and `disk1` could mean the same thing, the former referencing the container by its physical partition, and the latter by the virtual (*synthesized*) disk number.
+`diskN` (`N` >= 1) could be a disk image or an external disk, but more likely
+is an *APFS container*. Each *APFS container* contains multiple subvolumes,
+much like btrfs or zsh partitions contain multiple subvolumes. The "partitions"
+within such a disk aren't real partitions, they just represent volumes within
+one APFS container. The container itself exists within a physical partition in
+`disk0`, but is exposed as a separate disk on its own right too. That means
+that for APFS operations, for example, `disk0s2` and `disk1` could mean the
+same thing, the former referencing the container by its physical partition, and
+the latter by the virtual (*synthesized*) disk number.
 
 Multiple macOS installs can share one APFS container. Each OS has a *volume group* consisting of two paired subvolumes, a *System* volume and a *Data* volume. There are extra volumes: `Preboot`, `Recovery`, `VM`, `Update`. These are shared between all OSes in that container. Not all of them necessarily exist.
 


### PR DESCRIPTION
This isn't a hack; it's the same approach taken by other filesystems with subvolumes. Mention this explicitly.

Explain that containers are exposed as disks on their own right. A conclusion was made based on this fact, but it was not explicitly called out.