### PR TITLE
sw/broken-software: move Wine to fixed packages

### DIFF
--- a/docs/sw/broken-software.md
+++ b/docs/sw/broken-software.md
@@ -98,7 +98,6 @@ run). You may have varying levels of success by attempting to run your software 
 | jemalloc | <https://github.com/jemalloc/jemalloc/issues/467> | Upstream unwilling to fix, Needs build options if compiled on a 4k page size system. Addressed in [ArchLinuxARM](https://github.com/archlinuxarm/PKGBUILDs/pull/1914). |
 | MEGAsync | <https://github.com/meganz/MEGAsync/pull/801> |
 | notion-app(-enhancer) | <https://github.com/notion-enhancer/notion-repackaged/issues/107> | electron + broken build flags |
-| Wine | <https://bugs.winehq.org/show_bug.cgi?id=52715> |
 
 \* Running x86-64 software is supported via a 4k page size microVM running FEX.
 
@@ -129,6 +128,7 @@ run). You may have varying levels of success by attempting to run your software 
 | Telegram Desktop | <https://github.com/telegramdesktop/tdesktop/issues/26103> | Fixed since 4.1.1 |
 | Visual Studio Code | <https://aur.archlinux.org/packages/visual-studio-code-bin> | Fixed since 1.71.0 (uses Electron 19) |
 | WebKitGTK | <https://github.com/WebKit/WebKit/commit/0a4a03da45f774> | Fixed since 2.34.6 |
+| Wine | <https://bugs.winehq.org/show_bug.cgi?id=52715> | Fixed since 10.5 |
 | Zig | <https://github.com/ziglang/zig/issues/11308> | Fixed since [0.14.0](https://ziglang.org/download/0.14.0/release-notes.html#Runtime-Page-Size) |
 
 ## Bugs


### PR DESCRIPTION
According to [Wine Bugzilla](https://bugs.winehq.org/show_bug.cgi?id=52715), the problem has been fixed in 10.5.