### PR TITLE
platform: feature-support: update Touch Bar support

### DIFF
--- a/docs/platform/feature-support/m1.md
+++ b/docs/platform/feature-support/m1.md
@@ -80,7 +80,7 @@ These are features/hardware blocks that are present on all devices with the give
 | 10Gbps Ethernet    | 5.17                 | -                              | -                     | -                    |
 | Microphones        | -                    | linux-asahi                    | linux-asahi           | WIP                  |
 | Webcam             | -                    | linux-asahi                    | linux-asahi           | linux-asahi          |
-| Touch Bar          | -                    | linux-asahi                    | -                     | -                    |
+| Touch Bar          | -                    | 6.15                           | -                     | -                    |
 | TouchID            | TBA                  | TBA                            | TBA                   | TBA                  |
 
 ## M1 Pro/Max/Ultra devices

--- a/docs/platform/feature-support/m2.md
+++ b/docs/platform/feature-support/m2.md
@@ -81,7 +81,7 @@ These are features/hardware blocks that are present on all devices with the give
 | SD card slot       | -                              | -                              | -                              | -                  |
 | 1Gbps Ethernet     | -                              | -                              | -                              | 6.4 (dts)          |
 | 10Gbps Ethernet    | -                              | -                              | -                              | 6.4 (dts)          |
-| Touch Bar          | -                              | -                              | linux-asahi                    | -                  |
+| Touch Bar          | -                              | -                              | 6.15                           | -                  |
 | TouchID            | TBA                            | TBA                            | TBA                            | -                  |
 
 ## M2 Pro/Max/Ultra devices


### PR DESCRIPTION
Based on https://asahilinux.org/2025/05/progress-report-6-15/.

The feature support pages for M1 and M2 don't list any features having been upstreamed since 6.4.  Is that actually correct, or have other things been upstreamed but these tables have been forgotten, like with the Touch Bar?