### PR TITLE
Add FAQ entry about installing from an external macOS installation

### DIFF
--- a/docs/project/faq.md
+++ b/docs/project/faq.md
@@ -14,6 +14,10 @@ title: FAQ
 
 See the website for instructions: https://asahilinux.org/
 
+## Can I install Asahi Linux from an external macOS installation?
+
+[No](https://github.com/AsahiLinux/asahi-installer/issues/250). It is necessary to keep an *internal* macOS installation to install Asahi Linux, update/repair m1n1 and resize active Asahi Linux installations.
+
 ## How do I uninstall / clean up a failed installation?
 
 There is no automated uninstaller, but see [Partitioning cheatsheet](../sw/partitioning-cheatsheet.md) to learn how to delete the partitions manually.


### PR DESCRIPTION
As far as I know, the only place where this is explicitly documented is in a [GitHub issue](https://github.com/AsahiLinux/asahi-installer/issues/250) in the installer's repository. Figured it would be a good idea to add a FAQ entry about this.