### PR TITLE
display-controllers: fix list formatting

### DIFF
--- a/docs/hw/soc/display-controllers.md
+++ b/docs/hw/soc/display-controllers.md
@@ -3,6 +3,7 @@ title: Display Controllers
 ---
 
 M series of chips have two kinds of display controllers, `dcp` and `dcpext`. Both kinds support
+
 - DP 1.4 (4 lanes) with DSC. No MST!
 - HDMI via dp2hdmi converter. See below for routing restrictions.
 - USB-C ports: DP altmode, or USB4 tunneling with 2 controllers max per port. See below for routing restrictions.


### PR DESCRIPTION
Without the empty line before the list, it gets collapsed into the preceding paragraph (see https://asahilinux.org/docs/hw/soc/display-controllers/)