### PR TITLE
Add `site_description`

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: Asahi Linux Documentation
 site_url: https://asahilinux.org/docs/
+site_description: Porting Linux to Apple Silicon
 
 repo_url: https://github.com/AsahiLinux/docs
 repo_name: AsahiLinux/docs


### PR DESCRIPTION
First of all, thank you so much for this project! Can’t wait to switch back when M4 is supported (no worries, take your time :-)

I’ve noticed that description is not set for most pages and for the site itself (`site_description` in mkdocs.yml). This causes social previews to show `None` as the description:

<img width="318" height="244" alt="Image" src="https://github.com/user-attachments/assets/27d95cb0-a1c8-454b-8c82-4a757d587599" />

I think the easiest way to fix it would be to add a couple words to the `site_description`. I’ve copied over the one you use on the main site (“Porting Linux to Apple Silicon”), but you can choose something different if you want (or even override it for specific pages by setting `description` in the frontmatter).
