### PR TITLE
docs: Add M4 MacBook Air (13" and 15", 2025) to feature support

### DIFF
--- a/docs/platform/feature-support/m4.md
+++ b/docs/platform/feature-support/m4.md
@@ -62,25 +62,25 @@ These are features/hardware blocks that are present on all devices with the give
 
 
 ## M4 devices
-|                    | MacBook Pro<br>(14-inch, Nov 2024)  | MacBook Pro<br>(16-inch, Nov 2024) |
-|--------------------|:-----------------------------------:|:----------------------------------:|
-| Installer          | no                                  | no                                 |
-| Devicetree         | TBA                                 | TBA                                |
-| Main display       | TBA                                 | TBA                                |
-| Keyboard           | TBA                                 | TBA                                |
-| KB backlight       | TBA                                 | TBA                                |
-| Touchpad           | TBA                                 | TBA                                |
-| Brightness         | TBA                                 | TBA                                |
-| Battery info       | TBA                                 | TBA                                |
-| WiFi               | TBA                                 | TBA                                |
-| Bluetooth          | TBA                                 | TBA                                |
-| HDMI Out           | TBA                                 | TBA                                |
-| 3.5mm jack         | TBA                                 | TBA                                |
-| Speakers           | TBA                                 | TBA                                |
-| Microphones        | TBA                                 | TBA                                |
-| Webcam             | TBA                                 | TBA                                |
-| SD card slot       | TBA                                 | TBA                                |
-| TouchID            | TBA                                 | TBA                                |
+|                    | MacBook Pro<br>(14-inch, Nov 2024)  | MacBook Pro<br>(16-inch, Nov 2024) | MacBook Air<br>(13" and 15" 2025) |
+|--------------------|:-----------------------------------:|:----------------------------------:|:---------------------------------:|
+| Installer          | no                                  | no                                 | no                                |
+| Devicetree         | TBA                                 | TBA                                | TBA                               |
+| Main display       | TBA                                 | TBA                                | TBA                               |
+| Keyboard           | TBA                                 | TBA                                | TBA                               |
+| KB backlight       | TBA                                 | TBA                                | TBA                               |
+| Touchpad           | TBA                                 | TBA                                | TBA                               |
+| Brightness         | TBA                                 | TBA                                | TBA                               |
+| Battery info       | TBA                                 | TBA                                | TBA                               |
+| WiFi               | TBA                                 | TBA                                | TBA                               |
+| Bluetooth          | TBA                                 | TBA                                | TBA                               |
+| HDMI Out           | TBA                                 | TBA                                | -                                 |
+| 3.5mm jack         | TBA                                 | TBA                                | TBA                               |
+| Speakers           | TBA                                 | TBA                                | TBA                               |
+| Microphones        | TBA                                 | TBA                                | TBA                               |
+| Webcam             | TBA                                 | TBA                                | TBA                               |
+| SD card slot       | TBA                                 | TBA                                | -                                 |
+| TouchID            | TBA                                 | TBA                                | TBA                               |
 
 ## M4 Pro/Max devices
 |                    | Mac mini<br>(2024) | MacBook Pro<br>(14-inch, Nov 2024)  | MacBook Pro<br>(16-inch, Nov 2024) |


### PR DESCRIPTION
## Summary

Adds the newly released M4 MacBook Air to the M4 devices table in the feature support documentation.

**Devices added:**
- MacBook Air 13-inch (M4, 2025) - Mac16,12
- MacBook Air 15-inch (M4, 2025) - Mac16,13

**Release info:**
- Announced: March 5, 2025
- Released: March 12, 2025

Features are marked as TBA consistent with other M4 devices that don't yet have installer support. HDMI Out and SD card slot are marked as "-" since MacBook Air does not have these ports.

Closes #237