### PR TITLE
docs: Update partitioning cheatsheet to reflect Fedora as default

### DIFF
--- a/docs/sw/partitioning-cheatsheet.md
+++ b/docs/sw/partitioning-cheatsheet.md
@@ -53,7 +53,7 @@ Each macOS install has within it *its own copy of recoveryOS*. Then there is a g
 
 For Asahi Linux, we do not install alongside macOS in the same container, because that would require using APFS for Linux (which isn't stable yet nor mainlined). We just create normal GPT partitions for Linux. Asahi Linux also needs to install itself the same way macOS would, into an APFS container as a volume group, to be actually bootable. This is what we call the "stub macOS" and is what links the Apple world to the Linux world. Think of it as a bootloader partition. We *could* share a container with macOS for this, but we *choose* not to because it makes it less error-prone and easier to delete, and we're already partitioning the disk anyway.
 
-So the installer will (for a normal Asahi Linux = Arch Linux ARM install) create three partitions:
+So the installer will (for a normal Fedora Asahi Remix install) create three partitions:
 
 * A 2.5GB APFS container, containing the bits of iBoot/macOS we need to boot the machine including a copy of recoveryOS
     * m1n1 stage 1 is installed here


### PR DESCRIPTION
## Summary

Updates the partitioning cheatsheet to reflect that Fedora Asahi Remix is now the default/flagship distribution, replacing the outdated reference to Arch Linux ARM.

**Change:**
- `"for a normal Asahi Linux = Arch Linux ARM install"` → `"for a normal Fedora Asahi Remix install"`

This aligns the documentation with the current installer behavior and the [official Asahi Linux website](https://asahilinux.org/) which prominently features Fedora Asahi Remix.

Related: #118
Closes #221