### PR TITLE
index: remove stale list of blog posts

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -27,16 +27,5 @@ Check out [Feature Support](platform/feature-support/overview.md) for supported 
 and features. If you're after documentation on something specific, use the search feature
 at the top of the page or check out the sidebar for places to start!
 
-## Latest Asahi Linux blog posts
-* [Beyond Gaming: X11 bridging in muvm](https://asahilinux.org/2024/12/muvm-x11-bridging/)
-* [AAA gaming on Asahi Linux](https://asahilinux.org/2024/10/aaa-gaming-on-asahi-linux/)
-* [Vulkan 1.3 on the M1 in 1 month](https://asahilinux.org/2024/06/vk13-on-the-m1-in-1-month/)
-* [Conformant OpenGL 4.6 on the M1](https://asahilinux.org/2024/02/conformant-gl46-on-the-m1/)
-* [New in Fedora Asahi Remix](https://asahilinux.org/2024/01/fedora-asahi-new/)
-* [Our new flagship distro: Fedora Asahi Remix](https://asahilinux.org/2023/08/fedora-asahi-remix/)
-* [OpenGL 3.1 on Asahi Linux](https://asahilinux.org/2023/06/opengl-3-1-on-asahi-linux/)
-* [Paving the Road to Vulkan on Asahi Linux](https://asahilinux.org/2023/03/road-to-vulkan/)
-* [Apple GPU drivers now in Asahi Linux](https://asahilinux.org/2022/12/gpu-drivers-now-in-asahi-linux/)
-* [Updates galore! November 2022 Progress Report](https://asahilinux.org/2022/11/november-2022-report/)
-* [M2 is here! July 2022 Release & Progress Report](https://asahilinux.org/2022/07/july-2022-release/)
-* [The first Asahi Linux Alpha Release is here!](https://asahilinux.org/2022/03/asahi-linux-alpha-release/)
+Be sure to also read [our blog](https://asahilinux.org/blog/) where we post regular
+progress updates, as well as other news about the project.


### PR DESCRIPTION
Replace it with a generic pointer to the Asahi Linux blog - the recent blog post titles are largely just the progress updates. Let me know if you'd rather keep the list (and just have it updated), it's probably easy enough to script something based on the RSS if desired..