### PR TITLE
feature-support: reset M3/M4 support lists

### DIFF
--- a/docs/platform/feature-support/m3.md
+++ b/docs/platform/feature-support/m3.md
@@ -18,7 +18,6 @@ If a feature is not ready, then there is no estimation on when it will be ready.
 - [SoC blocks](#soc-blocks)
 - [M3 devices](#m3-devices)
 - [M3 Pro/Max devices](#m3-promax-devices)
-- [Notes](#notes)
 
 ## SoC blocks
 These are features/hardware blocks that are present on all devices with the given SoC.
@@ -26,60 +25,60 @@ These are features/hardware blocks that are present on all devices with the give
 |                  | M3<br>(T8122)        | M3 Pro/Max<br>(T603x)       |
 |------------------|:--------------------:|:---------------------------:|
 | DCP              | TBA                  | TBA                         |
-| USB2 (TB ports)  | linux-asahi          | linux-asahi                 |
-| USB3 (TB ports)  | linux-asahi          | linux-asahi                 |
+| USB2 (TB ports)  | WIP                  | WIP                         |
+| USB3 (TB ports)  | WIP                  | WIP                         |
 | Thunderbolt      | TBA                  | TBA                         |
 | DP Alt Mode      | WIP                  | WIP                         |
-| GPU              | TBA                  | TBA                         |
+| GPU              | WIP                  | WIP                         |
 | Video Decoder    | TBA                  | TBA                         |
-| NVMe             | 5.19                 | 5.19                        |
-| PCIe             | TBA                  | TBA                         |
+| NVMe             | WIP                  | WIP                         |
+| PCIe             | WIP                  | WIP                         |
 | PCIe (GE)        | -                    | -                           |
-| cpufreq          | 6.2                  | 6.2                         |
-| cpuidle          | linux-asahi ([notes](#cpuidle-situation)) | linux-asahi ([notes](#cpuidle-situation)) |
-| Suspend/sleep    | asahi-edge           | asahi-edge                  |
+| cpufreq          | TBA                  | TBA                         |
+| cpuidle          | TBA                  | TBA                         |
+| Suspend/sleep    | TBA                  | TBA                         |
 | Video Encoder    | TBA                  | TBA                         |
 | ProRes Codec     | TBA                  | TBA                         |
-| AICv3            | TBA                  | TBA                         |
+| AICv3            | WIP                  | WIP                         |
 | DART             | TBA                  | TBA                         |
 | PMU              | TBA                  | TBA                         |
-| UART             | 5.13                 | 5.13                        |
-| Watchdog         | 5.17                 | 5.17                        |
-| I<sup>2</sup>C   | 5.16                 | 5.16                        |
-| GPIO             | 5.16                 | 5.16                        |
-| USB-PD           | 5.16                 | 5.16                        |
-| MCA              | 6.1 / 6.4 (dts)      | linux-asahi                 |
-| SPI              | linux-asahi          | linux-asahi                 |
-| SPI NOR          | linux-asahi          | linux-asahi                 |
-| SMC              | linux-asahi          | linux-asahi                 |
-| SPMI             | linux-asahi          | linux-asahi                 |
-| RTC              | linux-asahi          | linux-asahi                 |
+| UART             | WIP                  | WIP                         |
+| Watchdog         | TBA                  | TBA                         |
+| I<sup>2</sup>C   | TBA                  | TBA                         |
+| GPIO             | TBA                  | TBA                         |
+| USB-PD           | WIP                  | WIP                         |
+| MCA              | TBA                  | TBA                         |
+| SPI              | TBA                  | TBA                         |
+| SPI NOR          | TBA                  | TBA                         |
+| SMC              | TBA                  | TBA                         |
+| SPMI             | WIP                  | WIP                         |
+| RTC              | TBA                  | TBA                         |
 | SEP              | WIP                  | WIP                         |
-| Neural Engine    | out of tree ([notes](#ane-driver)) | out of tree ([notes](#ane-driver)) |
+| Neural Engine    | TBA                  | TBA                         |
 
 
 ## M3 devices
 |                    | iMac<br>(2023)     | MacBook Pro<br>(14-inch, late 2023) | MacBook Air<br>(13” and 15” 2024) |
 |--------------------|:------------------:|:-----------------------------------:|:------------------------------:|
-| Installer          | no                 | no                                  |                                |
-| Devicetree         | TBA                | TBA                                 |                                |
-| Main display       | TBA                | TBA                                 |                                |
-| Keyboard           | -                  | TBA                                 |                                |
-| KB backlight       | -                  | TBA                                 |                                |
-| Touchpad           | -                  | TBA                                 |                                |
-| Brightness         | TBA                | TBA                                 |                                |
-| Battery info       | -                  | TBA                                 |                                |
-| WiFi               | TBA                | TBA                                 |                                |
-| Bluetooth          | TBA                | TBA                                 |                                |
+| Installer          | no                 | no                                  | no                             |
+| Devicetree         | TBA                | WIP                                 | WIP                            |
+| Main display       | TBA                | TBA                                 | TBA                            |
+| Keyboard           | -                  | TBA                                 | WIP                            |
+| KB backlight       | -                  | TBA                                 | WIP                            |
+| Touchpad           | -                  | TBA                                 | WIP                            |
+| Brightness         | TBA                | TBA                                 | TBA                            |
+| Battery info       | -                  | TBA                                 | TBA                            |
+| WiFi               | TBA                | TBA                                 | WIP                            |
+| Bluetooth          | TBA                | TBA                                 | TBA                            |
 | HDMI Out           | -                  | TBA                                 | -                              |
-| 3.5mm jack         | TBA                | TBA                                 |                                |
-| Speakers           | TBA                | TBA                                 |                                |
-| Microphones        | TBA                | TBA                                 |                                |
-| Webcam             | TBA                | TBA                                 |                                |
+| 3.5mm jack         | TBA                | TBA                                 | TBA                            |
+| Speakers           | TBA                | TBA                                 | TBA                            |
+| Microphones        | TBA                | TBA                                 | TBA                            |
+| Webcam             | TBA                | TBA                                 | TBA                            |
 | SD card slot       | -                  | TBA                                 | -                              |
 | 1Gbps Ethernet     | TBA                | -                                   | -                              |
 | 10Gbps Ethernet    | -                  | -                                   | -                              |
-| TouchID            | -                  | TBA                                 |                                |
+| TouchID            | -                  | TBA                                 | TBA                            |
 
 ## M3 Pro/Max devices
 |                    | MacBook Pro<br>(14/16-inch, late 2023) |
@@ -87,38 +86,22 @@ These are features/hardware blocks that are present on all devices with the give
 | Installer          | no                                |
 | Devicetree         | TBA                               |
 | Main display       | TBA                               |
-| Keyboard           | linux-asahi                       |
-| KB backlight       | linux-asahi                       |
-| Touchpad           | linux-asahi                       |
+| Keyboard           | WIP                               |
+| KB backlight       | WIP                               |
+| Touchpad           | WIP                               |
 | Brightness         | TBA                               |
-| Battery info       | linux-asahi                       |
+| Battery info       | TBA                               |
 | WiFi               | TBA                               |
 | Bluetooth          | TBA                               |
 | HDMI Out           | TBA                               |
-| 3.5mm jack         | linux-asahi                       |
-| Speakers           | WIP                               |
+| 3.5mm jack         | TBA                               |
+| Speakers           | TBA                               |
 | Microphones        | TBA                               |
 | Webcam             | TBA                               |
-| SD card slot       | 5.17                              |
+| SD card slot       | TBA                               |
 | 1Gbps Ethernet     | -                                 |
 | 10Gbps Ethernet    | -                                 |
 | TouchID            | TBA                               |
 
 Note: Many peripherals depend on DART and PCIe support.
 
-
-## Notes
-
-### cpuidle situation
-Some power management functionality on ARM machines is controlled via the PSCI interface. The
-kernel has a specific way of talking to PSCI that is not compatible with Apple Silicon, and a
-discussion is required with upstream maintainers in order to figure out the best way forward. Given
-that this discussion has failed to materialise for two years, the decision has been
-made to hack together a driver that directly calls WFI/WFE instructions in order to bring
-this functionality to Asahi Linux. This greatly improves the UX on laptops when coupled with
-energy-aware scheduling, as it resolves the issue of the machines running warm to the touch
-and significantly improves battery life. This can never be upstreamed, however the hope is
-that this hacked together driver becomes unnecessary at some point in the near future.
-
-### ANE driver
-An out of tree [kernel module](https://github.com/eiln/ane/tree/main) is available. It will be merged into linux-asahi.

--- a/docs/platform/feature-support/m4.md
+++ b/docs/platform/feature-support/m4.md
@@ -18,7 +18,6 @@ If a feature is not ready, then there is no estimation on when it will be ready.
 - [SoC blocks](#soc-blocks)
 - [M4 devices](#m4-devices)
 - [M4 Pro/Max devices](#m4-promax-devices)
-- [Notes](#notes)
 
 ## SoC blocks
 These are features/hardware blocks that are present on all devices with the given SoC.
@@ -26,36 +25,36 @@ These are features/hardware blocks that are present on all devices with the give
 |                  | M4<br>(T8132)        | M4 Pro/Max<br>(T604x)       |
 |------------------|:--------------------:|:---------------------------:|
 | DCP              | TBA                  | TBA                         |
-| USB2 (TB ports)  | linux-asahi          | linux-asahi                 |
-| USB3 (TB ports)  | linux-asahi          | linux-asahi                 |
+| USB2 (TB ports)  | TBA                  | TBA                         |
+| USB3 (TB ports)  | TBA                  | TBA                         |
 | Thunderbolt      | TBA                  | TBA                         |
-| DP Alt Mode      | WIP                  | WIP                         |
+| DP Alt Mode      | TBA                  | TBA                         |
 | GPU              | TBA                  | TBA                         |
 | Video Decoder    | TBA                  | TBA                         |
-| NVMe             | 5.19                 | 5.19                        |
+| NVMe             | TBA                  | TBA                         |
 | PCIe             | TBA                  | TBA                         |
 | PCIe (GE)        | -                    | -                           |
-| cpufreq          | 6.2                  | 6.2                         |
-| cpuidle          | linux-asahi ([notes](#cpuidle-situation)) | linux-asahi ([notes](#cpuidle-situation)) |
-| Suspend/sleep    | asahi-edge           | asahi-edge                  |
+| cpufreq          | TBA                  | TBA                         |
+| cpuidle          | TBA                  | TBA                         |
+| Suspend/sleep    | TBA                  | TBA                         |
 | Video Encoder    | TBA                  | TBA                         |
 | ProRes Codec     | TBA                  | TBA                         |
 | AICv3            | TBA                  | TBA                         |
 | DART             | TBA                  | TBA                         |
 | PMU              | TBA                  | TBA                         |
-| UART             | 5.13                 | 5.13                        |
-| Watchdog         | 5.17                 | 5.17                        |
-| I<sup>2</sup>C   | 5.16                 | 5.16                        |
-| GPIO             | 5.16                 | 5.16                        |
-| USB-PD           | 5.16                 | 5.16                        |
-| MCA              | 6.1 / 6.4 (dts)      | linux-asahi                 |
-| SPI              | linux-asahi          | linux-asahi                 |
-| SPI NOR          | linux-asahi          | linux-asahi                 |
-| SMC              | linux-asahi          | linux-asahi                 |
-| SPMI             | linux-asahi          | linux-asahi                 |
-| RTC              | linux-asahi          | linux-asahi                 |
-| SEP              | WIP                  | WIP                         |
-| Neural Engine    | out of tree ([notes](#ane-driver)) | out of tree ([notes](#ane-driver)) |
+| UART             | TBA                  | TBA                         |
+| Watchdog         | TBA                  | TBA                         |
+| I<sup>2</sup>C   | TBA                  | TBA                         |
+| GPIO             | TBA                  | TBA                         |
+| USB-PD           | TBA                  | TBA                         |
+| MCA              | TBA                  | TBA                         |
+| SPI              | TBA                  | TBA                         |
+| SPI NOR          | TBA                  | TBA                         |
+| SMC              | TBA                  | TBA                         |
+| SPMI             | TBA                  | TBA                         |
+| RTC              | TBA                  | TBA                         |
+| SEP              | TBA                  | TBA                         |
+| Neural Engine    | TBA                  | TBA                         |
 
 
 ## M4 devices
@@ -104,19 +103,3 @@ These are features/hardware blocks that are present on all devices with the give
 
 Note: Many peripherals depend on DART and PCIe support.
 
-
-## Notes
-
-### cpuidle situation
-Some power management functionality on ARM machines is controlled via the PSCI interface. The
-kernel has a specific way of talking to PSCI that is not compatible with Apple Silicon, and a
-discussion is required with upstream maintainers in order to figure out the best way forward. Given
-that this discussion has failed to materialise for two years, the decision has been
-made to hack together a driver that directly calls WFI/WFE instructions in order to bring
-this functionality to Asahi Linux. This greatly improves the UX on laptops when coupled with
-energy-aware scheduling, as it resolves the issue of the machines running warm to the touch
-and significantly improves battery life. This can never be upstreamed, however the hope is
-that this hacked together driver becomes unnecessary at some point in the near future.
-
-### ANE driver
-An out of tree [kernel module](https://github.com/eiln/ane/tree/main) is available. It will be merged into linux-asahi.


### PR DESCRIPTION
The support lists for M3/M4 were inaccurate - and since nothing is supported in Fedora Asahi Remix, I'm assuming it doesn't make sense to mark anything as stable/upstream yet. I marked all the M3/M4 features as 'TBA', except those M3 features which work or where I'm aware that someone is actively working on them, which are now 'WIP'. The result is a bit pessimistic (no doubt some of this works already on M4, and I'm sure there are other things which are WIP on M3). Better than nothing..?